### PR TITLE
Expenses: Use icons from Budget data in views

### DIFF
--- a/src/renderer/components/Budget.vue
+++ b/src/renderer/components/Budget.vue
@@ -325,7 +325,7 @@ export default {
           self.displayAlert('mdi-alert-octagon', 'red', err, 60)
         } else {
           // Set Category List from budget entries
-          self.categories = cats
+          self.categories = Object.keys(cats)
         }
       })
     },

--- a/src/renderer/components/ExpenseCategory.vue
+++ b/src/renderer/components/ExpenseCategory.vue
@@ -12,7 +12,7 @@
         <v-list>
           <v-list-tile class="grey lighten-1" v-for="(item,i) in entry" :key="i">
             <v-list-tile-avatar>
-              <v-icon>mdi-currency-usd-off</v-icon>
+              <v-icon>{{ item.icon }}</v-icon>
             </v-list-tile-avatar>
             <v-layout row align-center>
               <v-flex xs1>{{ entryType }}</v-flex>
@@ -27,7 +27,7 @@
   <template v-else>
     <v-list-tile :class="entryColor">
       <v-list-tile-avatar>
-        <v-icon>mdi-currency-usd-off</v-icon>
+        <v-icon>{{ entry.icon }}</v-icon>
       </v-list-tile-avatar>
       <v-layout row align-center>
         <v-flex xs1>{{ entryType }}</v-flex>

--- a/src/renderer/components/ExpenseEntry.vue
+++ b/src/renderer/components/ExpenseEntry.vue
@@ -3,7 +3,7 @@
 
   <v-list-tile :class="entryColor">
     <v-list-tile-avatar>
-      <v-icon>mdi-currency-usd-off</v-icon>
+      <v-icon>{{ entry.icon }}</v-icon>
     </v-list-tile-avatar>
     <v-layout row>
       <v-flex xs1>{{ entryType }}</v-flex>

--- a/src/renderer/components/Expenses.vue
+++ b/src/renderer/components/Expenses.vue
@@ -383,6 +383,7 @@ export default {
 
         this.entry.amount = parseFloat(this.entry.amount)
         this.entry.type = this.entry.amount > 0 ? Constants.TYPE_INCOME : Constants.TYPE_EXPENSE
+        this.entry.icon = this.iconMap[this.entry.category] || 'mdi-currency-usd-off'
 
         ExpenseDB.save(this.entry, function (err, numReplaced, upsert) {
           if (err) {
@@ -427,8 +428,7 @@ export default {
       promise
         .then(function (docs) {
           if (self.viewStyle === Constants.VIEW_STYLE_GROUP) {
-            var loadCatData = self._loadCategoryDataByMonth(self.startDate.getMonth())
-            loadCatData
+            self._loadCategoryDataByMonth(self.startDate.getMonth())
               .then(function (cats) {
                 self.categoriesForMonth = cats
                 self._groupExpensesData(docs)
@@ -471,13 +471,15 @@ export default {
         var budgetedAmount = this.categoriesForMonth[cat] || 0.0
         var type = budgetedAmount >= 0.0 ? Constants.TYPE_INCOME : Constants.TYPE_EXPENSE
 
+        var icon = 'mdi-coin'
         if (catEntries.length > 0) {
+          icon = catEntries[0].icon
           catEntries.forEach(function (entry) {
             totalAmount += entry.amount
           })
         }
 
-        var newEntry = {type: type, category: cat, amount: totalAmount, budgetedAmount: budgetedAmount}
+        var newEntry = {type: type, icon: icon, category: cat, amount: totalAmount, budgetedAmount: budgetedAmount}
 
         if (cat.startsWith('UNBUDGETED')) {
           unbudgtedEntries.push(newEntry)
@@ -493,12 +495,16 @@ export default {
 
     _loadCategoryData: function () {
       var self = this
+      // Load Categories (includes icons)
       BudgetDB.loadCategories(function (err, cats) {
         if (err) {
           self.displayAlert('mdi-alert-octagon', 'red', err, 60)
         } else {
+          // Mapping from Category name to Icon
+          self.iconMap = cats
+
           // Set Category List from budget entries
-          self.categories = cats.concat(['UNBUDGETED'])
+          self.categories = Object.keys(cats).concat(['UNBUDGETED'])
         }
       })
     },
@@ -550,6 +556,7 @@ export default {
       constants: Constants,
       categoriesForMonth: null,
       categories: [],
+      iconMap: {},
       format: Format,
       viewStyle: Constants.VIEW_STYLE_GROUP,
       incomeExpenseView: Constants.IE_VIEW_TO_DATE,
@@ -572,6 +579,7 @@ export default {
       entry: {
         type: null,
         date: null,
+        icon: null,
         category: null,
         amount: null,
         notes: null

--- a/src/renderer/lib/BudgetDB.js
+++ b/src/renderer/lib/BudgetDB.js
@@ -68,15 +68,20 @@ export default {
   },
 
   loadCategories: function (cb) {
-    _DB.find({}, {_id: 0, category: 1}).sort({category: 1}).exec(function (err, docs) {
+    var fields = {
+      _id: 0,
+      icon: 1,
+      category: 1
+    }
+
+    _DB.find({}, fields).sort({category: 1}).exec(function (err, docs) {
       if (err) {
         cb(err, null)
       } else {
-        var allCats = docs.map(function (doc) {
-          return (doc.category)
+        var uniqueCats = {}
+        docs.forEach(function (doc) {
+          uniqueCats[doc.category] = doc.icon
         })
-        var uniqueCats = Array.from(new Set(allCats))
-
         cb(null, uniqueCats)
       }
     })

--- a/src/renderer/lib/ExpenseDB.js
+++ b/src/renderer/lib/ExpenseDB.js
@@ -68,6 +68,7 @@ export default {
         self.save({
           type: Constants.TYPE_INCOME,
           date: currMonthStart,
+          icon: 'mdi-transfer',
           category: CAT_ROLLOVER,
           amount: income + expense,
           notes: 'Balance Rolled Over from Previous Month'


### PR DESCRIPTION
Icons, that match the icon associated with a Budget category, now appear in
the List and Group Expenses view instead of a hard-coded icon